### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Zohnannor <zohnannor@gmail.com>"]
 license-file = "LICENSE"
 keywords = ["iterator", "trait"]
 categories = ["no-std", "rust-patterns"]
-repository = "http://github.com/zohnannor/for_each_repeat/"
+repository = "https://github.com/zohnannor/for_each_repeat/"
 readme = "README.md"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97